### PR TITLE
Update .gitignore and keys for db connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
+.env.development
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/backend/src/db/index.js
+++ b/backend/src/db/index.js
@@ -1,7 +1,11 @@
 const pg = require("pg");
 
 const client = new pg.Client({
-  connectionString: process.env.DATABASE_URL || "",
+  host: process.env.PGHOST,
+  name: process.env.PGDATABASE,
+  user: process.env.PGUSER,
+  password: process.env.PGPASSWORD,
+  port: process.env.PGPORT,
   ssl: process.env.DATABASE_URL ? { rejectUnauthorized: false } : false
 });
 


### PR DESCRIPTION
Fixes corrective maintenance issue: [PhotoLabs backend missing instructions#2160](https://github.com/lighthouse-labs/2019-web-bootcamp/issues/2160)