### PR TITLE
Best Practice: Remove `defaultProps`

### DIFF
--- a/frontend/src/components/PhotoList.jsx
+++ b/frontend/src/components/PhotoList.jsx
@@ -1,6 +1,60 @@
-import React from 'react';
+import React from "react";
 
-import '../styles/PhotoList.scss';
+import "../styles/PhotoList.scss";
+
+const photos = [
+  {
+    id: "1",
+    location: {
+      city: "Montreal",
+      country: "Canada",
+    },
+    urls: {
+      full: `${process.env.PUBLIC_URL}/Image-1-Full.jpeg`,
+      regular: `${process.env.PUBLIC_URL}/Image-1-Regular.jpeg`,
+    },
+    user: {
+      id: "1",
+      username: "exampleuser",
+      name: "Joe Example",
+      profile: `${process.env.PUBLIC_URL}/profile-1.jpg`,
+    },
+  },
+  {
+    id: "2",
+    location: {
+      city: "Toronto",
+      country: "Canada",
+    },
+    urls: {
+      full: `${process.env.PUBLIC_URL}/Image-2-Full.jpeg`,
+      regular: `${process.env.PUBLIC_URL}/Image-2-Regular.jpeg`,
+    },
+    user: {
+      id: "2",
+      username: "exampleuser",
+      name: "Joe Example",
+      profile: `${process.env.PUBLIC_URL}/profile-1.jpg`,
+    },
+  },
+  {
+    id: "3",
+    location: {
+      city: "Ottawa",
+      country: "Canada",
+    },
+    urls: {
+      full: `${process.env.PUBLIC_URL}/Image-3-Full.jpeg`,
+      regular: `${process.env.PUBLIC_URL}/Image-3-Regular.jpeg`,
+    },
+    user: {
+      id: "3",
+      username: "exampleuser",
+      name: "Joe Example",
+      profile: `${process.env.PUBLIC_URL}/profile-1.jpg`,
+    },
+  },
+];
 
 const PhotoList = () => {
   <ul className="photo-list">
@@ -8,60 +62,4 @@ const PhotoList = () => {
   </ul>
 }
 
-PhotoList.defaultProps = {
-  photos: [
-    {
-      "id": "1",
-      "location": {
-        "city": "Montreal",
-        "country": "Canada"
-      },
-      "urls": {
-        "full": `${process.env.PUBLIC_URL}/Image-1-Full.jpeg`,
-        "regular": `${process.env.PUBLIC_URL}/Image-1-Regular.jpeg`
-      },
-      "user": {
-        "id": "1",
-        "username": "exampleuser",
-        "name": "Joe Example",
-        "profile": `${process.env.PUBLIC_URL}/profile-1.jpg`
-      }
-    },
-    {
-      "id": "2",
-      "location": {
-        "city": "Toronto",
-        "country": "Canada"
-      },
-      "urls": {
-        "full": `${process.env.PUBLIC_URL}/Image-2-Full.jpeg`,
-        "regular": `${process.env.PUBLIC_URL}/Image-2-Regular.jpeg`
-      },
-      "user": {
-        "id": "2",
-        "username": "exampleuser",
-        "name": "Joe Example",
-        "profile": `${process.env.PUBLIC_URL}/profile-1.jpg`
-      }
-    },
-    {
-      "id": "3",
-      "location": {
-        "city": "Ottawa",
-        "country": "Canada"
-      },
-      "urls": {
-        "full": `${process.env.PUBLIC_URL}/Image-3-Full.jpeg`,
-        "regular": `${process.env.PUBLIC_URL}/Image-3-Regular.jpeg`
-      },
-      "user": {
-        "id": "3",
-        "username": "exampleuser",
-        "name": "Joe Example",
-        "profile": `${process.env.PUBLIC_URL}/profile-1.jpg`
-      }
-    }
-   ]
-}
-
-export default PhotoList
+export default PhotoList;

--- a/frontend/src/components/PhotoListItem.jsx
+++ b/frontend/src/components/PhotoListItem.jsx
@@ -1,21 +1,20 @@
+import React from "react";
 
-import React from 'react';
+import "../styles/PhotoListItem.scss";
 
-import '../styles/PhotoListItem.scss';
+const photo = {
+  id: "1",
+  location: {
+    city: "Montreal",
+    country: "Canada",
+  },
+  imageSource: `${process.env.PUBLIC_URL}/Image-1-Regular.jpeg`,
+  username: "Joe Example",
+  profile: `${process.env.PUBLIC_URL}/profile-1.jpg`,
+};
 
 const PhotoListItem = () => {
   /* Insert React */
-}
+};
 
-PhotoListItem.defaultProps = {
-  "id": "1",
-  "location": {
-    "city": "Montreal",
-    "country": "Canada"
-  },
-  "imageSource": `${process.env.PUBLIC_URL}/Image-1-Regular.jpeg`,
-  "username": "Joe Example",
-  "profile": `${process.env.PUBLIC_URL}/profile-1.jpg`
-}
-
-export default PhotoListItem
+export default PhotoListItem;

--- a/frontend/src/components/TopicList.jsx
+++ b/frontend/src/components/TopicList.jsx
@@ -1,30 +1,29 @@
-import React from 'react';
+import React from "react";
 
-import './TopicList.scss';
+import "./TopicList.scss";
+
+const topics = [
+  {
+    id: "1",
+    slug: "topic-1",
+    title: "Nature",
+  },
+  {
+    id: "2",
+    slug: "topic-2",
+    title: "Travel",
+  },
+  {
+    id: "3",
+    slug: "topic-3",
+    title: "People",
+  },
+];
 
 const TopicList = () => {
   <div className="top-nav-bar__topic-list">
     {/* Insert React */}
   </div>
-}
+};
 
-TopicList.defaultProps = {
-  topics: [
-    {
-      "id": "1",
-      "slug": "topic-1",
-      "title": "Nature"
-    },  
-    {
-      "id": "2",
-      "slug": "topic-2",
-      "title": "Travel"
-    },
-    {
-      "id": "3",
-      "slug": "topic-3",
-      "title": "People"
-    },
-  ]
-}
-export default TopicList
+export default TopicList;

--- a/frontend/src/components/TopicListItem.jsx
+++ b/frontend/src/components/TopicListItem.jsx
@@ -1,16 +1,17 @@
-import React from 'react';
+import React from "react";
 
-import '../styles/TopicListItem'
+import "../styles/TopicListItem";
+
+const topic = {
+  id: "1",
+  slug: "topic-1",
+  label: "Nature",
+};
 
 const TopicListItem = () => {
   <div className="topic-list__item">
     {/* Insert React */}
   </div>
-}
+};
 
-TopicListItem.defaultProps =   {
-  "id": "1",
-  "slug": "topic-1",
-  "label": "Nature"
-}
-export default TopicListItem
+export default TopicListItem;


### PR DESCRIPTION
* `defaultProps` are being deprecated by React in version 18.3 (current version is 18.2) so this curriculum is not "future-proof".
* This PR represents one alternative to using `defaultProps`, but it is not the only solution available.