### PR TITLE
Best Practice: Simplify SVG Usage

### DIFF
--- a/frontend/src/assets/closeSymbol.svg
+++ b/frontend/src/assets/closeSymbol.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clipPath="url(#clip0_428_287)">
+    <path d="M14.0625 3.9375L3.9375 14.0625" stroke="black" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M14.0625 14.0625L3.9375 3.9375" stroke="black" strokeLinecap="round" strokeLinejoin="round"/>
+  </g>
+  <defs>
+    <clipPath id="clip0_428_287">
+    <rect width="18" height="18" fill="white"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/frontend/src/components/FavBadge.jsx
+++ b/frontend/src/components/FavBadge.jsx
@@ -3,10 +3,10 @@ import FavIcon from './FavIcon';
 
 import '../styles/FavBadge.scss';
 
-export const FavBadge = ({ isFavPhotoExist }) => {
+const FavBadge = ({ isFavPhotoExist }) => {
   return (
     <div className='fav-badge'>
-      <FavIcon width={20} height={17} fill="#C80000" displayAlert={!!isFavPhotoExist}/>
+      <FavIcon displayAlert={!!isFavPhotoExist}/>
     </div>
   ) 
 };

--- a/frontend/src/components/FavIcon.jsx
+++ b/frontend/src/components/FavIcon.jsx
@@ -1,25 +1,15 @@
 import React from 'react';
 
-export function FavIcon({
-  width, height, fill, outlineWidth, stroke, displayAlert
-}) {
+const FavIcon = ({displayAlert}) => {
   return (
-    <svg width={width} height={height} viewBox="0 0 24 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M11 18C11 18 1 12.5909 1 6.02273C1 4.8616 1.41649 3.73633 2.17862 2.83838C2.94075 1.94043 4.00143 1.32526 5.1802 1.09755C6.35897 0.869829 7.58301 1.04363 8.64406 1.58938C9.70512 2.13512 10.5376 3.0191 11 4.09092C11.4624 3.0191 12.2949 2.13512 13.3559 1.58938C14.417 1.04363 15.641 0.869829 16.8198 1.09755C17.9986 1.32526 19.0593 1.94043 19.8214 2.83838C20.5835 3.73633 21 4.8616 21 6.02273C21 12.5909 11 18 11 18Z" fill={fill} stroke={stroke} strokeWidth={outlineWidth} strokeLinecap="round" strokeLinejoin="round"/>
+    <svg width="20" height="17" viewBox="0 0 24 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M11 18C11 18 1 12.5909 1 6.02273C1 4.8616 1.41649 3.73633 2.17862 2.83838C2.94075 1.94043 4.00143 1.32526 5.1802 1.09755C6.35897 0.869829 7.58301 1.04363 8.64406 1.58938C9.70512 2.13512 10.5376 3.0191 11 4.09092C11.4624 3.0191 12.2949 2.13512 13.3559 1.58938C14.417 1.04363 15.641 0.869829 16.8198 1.09755C17.9986 1.32526 19.0593 1.94043 19.8214 2.83838C20.5835 3.73633 21 4.8616 21 6.02273C21 12.5909 11 18 11 18Z" fill="#EEEEEE" stroke="#C80000" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
       {
           !!displayAlert &&
           <circle cx="21" cy="4" r="2.75" fill="#FFFF00" stroke="#C80000" strokeWidth="0.5"/>
       }
     </svg>
   );
-}
-
-FavIcon.defaultProps = {
-  width: 20,
-  height: 17,
-  fill: '#EEEEEE',
-  outlineWidth: 2,
-  stroke: '#C80000',
-}
+};
 
 export default FavIcon;

--- a/frontend/src/components/PhotoFavButton.jsx
+++ b/frontend/src/components/PhotoFavButton.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 
-import { FavIcon } from './FavIcon';
+import FavIcon from './FavIcon';
 import '../styles/PhotoFavButton.scss';
 
 function PhotoFavButton() {

--- a/frontend/src/routes/PhotoDetailsModal.jsx
+++ b/frontend/src/routes/PhotoDetailsModal.jsx
@@ -1,21 +1,12 @@
 import React from 'react';
 
 import '../styles/PhotoDetailsModal.scss'
+import closeSymbol from '../assets/closeSymbol';
 
 export const PhotoDetailsModal = () => (
   <div className='photo-details-modal'>
     <button className='photo-details-modal--close-button'>
-      <svg width="24" height="24" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <g clipPath="url(#clip0_428_287)">
-          <path d="M14.0625 3.9375L3.9375 14.0625" stroke="black" strokeLinecap="round" strokeLinejoin="round"/>
-          <path d="M14.0625 14.0625L3.9375 3.9375" stroke="black" strokeLinecap="round" strokeLinejoin="round"/>
-        </g>
-        <defs>
-          <clipPath id="clip0_428_287">
-          <rect width="18" height="18" fill="white"/>
-          </clipPath>
-        </defs>
-      </svg>
+      <img src={closeSymbol} alt="close symbol" />
     </button>
   </div>
 )

--- a/frontend/src/routes/PhotoDetailsModal.jsx
+++ b/frontend/src/routes/PhotoDetailsModal.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
 import '../styles/PhotoDetailsModal.scss'
-import closeSymbol from '../assets/closeSymbol';
+import closeSymbol from '../assets/closeSymbol.svg';
 
-export const PhotoDetailsModal = () => (
-  <div className='photo-details-modal'>
-    <button className='photo-details-modal--close-button'>
+const PhotoDetailsModal = () => (
+  <div className="photo-details-modal">
+    <button className="photo-details-modal--close-button">
       <img src={closeSymbol} alt="close symbol" />
     </button>
   </div>
-)
+);
 
 export default PhotoDetailsModal;


### PR DESCRIPTION
* Moves the "close button" SVG to a separate file to improve component clarity.
* Removes all unneeded props from `FavIcon` component.
* Removes duplicate exports from affected components.
* Updates any current imports to reflect the changes above.