### PR TITLE
Modify readme instructions to avoid user permission clashes in psql

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,7 +6,7 @@ Install dependencies with `npm install`.
 
 ## Creating The DB
 
-Use the `psql -U development` command to login to the PostgreSQL server with the username `development` and the password `development`. This command **MUST** be run in a vagrant terminal, we are using the PostgreSQL installation provided in the vagrant environment. M1/M2 and WSL2 users can execute this command in their terminal.
+Use the `psql -U labber` command to login to the PostgreSQL server with the username `labber` and the password `labber`. This command **MUST** be run in a vagrant terminal, we are using the PostgreSQL installation provided in the vagrant environment. M1/M2 and WSL2 users can execute this command in their terminal.
 
 Create a database with the command `CREATE DATABASE photolabs_development;`.
 


### PR DESCRIPTION
The backend setup readme file tells students to create the database with user `development`, but then manage it with user `labber`.
This conflicts because `labber` doesn't have permission to modify anything that is created by other users.